### PR TITLE
Prevent agent interval skew by re-using ticker

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,9 +31,10 @@ type Agent struct {
 }
 
 func (a *Agent) Start() {
+	ticker := time.NewTicker(a.FlushInterval)
 	for {
 		select {
-		case <-time.NewTicker(a.FlushInterval).C:
+		case <-ticker.C:
 			err := a.flush()
 			if err != nil {
 				log.Printf("agent %d: %s\n", a.ID, err)


### PR DESCRIPTION
#### Summary
One of Ticker's features is that it adjusts it's "Ticks" to compensate for skew. Because the agent's  ticker is created anew with each iteration of the loop in Start(), we lose this feature

#### Problem
With large agent counts and loaded carbon servers, agent flush times tend to skew over time so that they begin distributing more randomly. When simulating Carbon load, it's often desired to simulate a large number of agents that flush almost simultaneously (e.g. minutely flushing colllectd agents which were all restarted at the same time, or a client that flushes at the top of every minute on servers that run ntp).

#### Changes
Create the agent's Ticker at the beginning of Start(), before we enter the main for loop

#### Testing done
Started a haggar run with many agents with a -spawn-interval of 0s and a -jitter of 1ns. Watched time skew over time to verify flush times remain consistent over time