### PR TITLE
Prevent jitter from skewing spawnInterval at agent launch

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"syscall"
 	"time"
+	"fmt"
 )
 
 // config vars, to be manipulated via command line flags
@@ -85,13 +86,19 @@ func init() {
 func main() {
 	flag.Parse()
 
+	if jitter > spawnInterval {
+		flag.PrintDefaults()
+		fmt.Print("\n\nError: jitter value must be less than or equal to spawn-interval\n\n")
+		os.Exit(1)
+	}
+
 	spawnAgents := true
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGUSR1)
 
 	// start timer at 1 milli so we launch an agent right away
 	timer := time.NewTimer(1 * time.Millisecond)
-
+	jitterDelay := time.Duration(0)
 	curID := 0
 
 	log.Printf("master: pid %d\n", os.Getpid())
@@ -107,8 +114,16 @@ func main() {
 					go launchAgent(curID, metrics, flushInterval, carbon, prefix)
 					log.Printf("agent %d: launched\n", curID)
 					curID++
+					// Subtract the last jitter val ue to keep spawnInterval a consistent baseline
+					nextLaunch := spawnInterval - jitterDelay
 
-					timer = time.NewTimer(spawnInterval + (time.Duration(rand.Int63n(jitter.Nanoseconds()))))
+					if jitter.Nanoseconds() != 0 {
+						// rand(jitter * 2) - jitter gives random +/- jitter values
+						jitterDelay = time.Duration(rand.Int63n(jitter.Nanoseconds() * 2) - jitter.Nanoseconds())
+					}
+					nextLaunch += jitterDelay
+
+					timer = time.NewTimer(nextLaunch)
 				}
 			}
 		}


### PR DESCRIPTION
#### Summary
Prevent jitter values from skewing spawnInterval

#### Problem
When using a spawnInterval and a jitter, agent spawns will happen on average later than spawnInterval, causing agents to skew later and later from their original <start time> % spawnInterval. E.g. for a -spawn-interval 10s and -jitter 2s, launches will look like:
1:00:00
1:00:11
1:00:23
1:00:33
1:00:45
1:00:56
etc

This is an issue when trying to simulate agents that flush nearly all at once - e.g. collectd agents that were all started nearly at the same time.

#### Changes
Calculate jitter as a random  +/- jitter max, scheduling the next timer baseline as if no jitter had occurred. Also fix #18 by ignoring jitter if it's set to 0s. 

#### Testing done
Launched many agents with a -spawnInterval 10s and -jitter 2s
Verified agent spawns occur within 2 seconds of consistent 10 second intervals

Launched agents with a -spawnInterval 10s and -jitter 0s
Verified agents spawns occur at consistent 10 second intervals 