### PR TITLE
Explicitly nil the agent connection if caching is disabled.

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,7 +56,10 @@ func (a *Agent) flush() error {
 	}
 
 	if !cacheConns {
-		defer a.Connection.Close()
+		defer func() {
+			a.Connection.Close()
+			a.Connection = nil
+		}()
 	}
 
 	epoch := time.Now().Unix()


### PR DESCRIPTION
# Explicitly nil the agent connection if caching is disabled

With caching disabled, every alternating metric send fails because it will be attempted on a closed connection - this was the cause of the 50% throughput issue @obfuscurity reported.

master:

```
$ ./haggar -agents=3 -metrics=1 -carbon=localhost:2003 -cache_connections=false
2017/01/01 21:28:43 master: pid 36203
2017/01/01 21:28:43 agent 0: launched
2017/01/01 21:28:53 agent 0: flushed 1 metrics
2017/01/01 21:28:55 agent 1: launched
2017/01/01 21:29:03 agent 0: write tcp 127.0.0.1:63932->127.0.0.1:2003: use of closed network connection
2017/01/01 21:29:05 agent 2: launched
2017/01/01 21:29:05 agent 1: flushed 1 metrics
2017/01/01 21:29:13 agent 0: flushed 1 metrics
2017/01/01 21:29:15 agent 2: flushed 1 metrics
2017/01/01 21:29:15 agent 1: write tcp 127.0.0.1:63934->127.0.0.1:2003: use of closed network connection
```

fix-cached-connection-nil-check:

```
$ ./haggar -agents=3 -metrics=1 -carbon=localhost:2003 -cache_connections=false
2017/01/01 21:30:00 master: pid 35558
2017/01/01 21:30:00 agent 0: launched
2017/01/01 21:30:10 agent 0: flushed 1 metrics
2017/01/01 21:30:12 agent 1: launched
2017/01/01 21:30:20 agent 0: flushed 1 metrics
2017/01/01 21:30:22 agent 2: launched
2017/01/01 21:30:22 agent 1: flushed 1 metrics
2017/01/01 21:30:30 agent 0: flushed 1 metrics
2017/01/01 21:30:32 agent 2: flushed 1 metrics
2017/01/01 21:30:32 agent 1: flushed 1 metrics
```

fixes https://github.com/gorsuch/haggar/issues/21